### PR TITLE
Support escape/backspace in canvas tools

### DIFF
--- a/CircuitPro/Features/Canvas/AppKit/CoreGraphicsCanvasView.swift
+++ b/CircuitPro/Features/Canvas/AppKit/CoreGraphicsCanvasView.swift
@@ -133,9 +133,24 @@ final class CoreGraphicsCanvasView: NSView {
                 interaction.enterRotationMode(around: center)
             }
 
+        case "\u{1b}":
+            if var tool = selectedTool, tool.id != "cursor" {
+                tool.handleEscape()
+                selectedTool = tool
+                needsDisplay = true
+            } else {
+                super.keyDown(with: event)
+            }
+
         case String(UnicodeScalar(NSDeleteCharacter)!),
              String(UnicodeScalar(NSBackspaceCharacter)!):
-            deleteSelectedElements()
+            if var tool = selectedTool, tool.id != "cursor" {
+                tool.handleBackspace()
+                selectedTool = tool
+                needsDisplay = true
+            } else {
+                deleteSelectedElements()
+            }
 
         default:
             super.keyDown(with: event)

--- a/CircuitPro/Features/Toolbar/Tool/AnyCanvasTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/AnyCanvasTool.swift
@@ -14,8 +14,10 @@ struct AnyCanvasTool: CanvasTool {
     let label: String
 
     private let _handleTap: (CGPoint, CanvasToolContext) -> CanvasElement?
-     private let _drawPreview: (CGContext, CGPoint, CanvasToolContext) -> Void
-     private let box: ToolBoxBase          // <— keeps the ToolBox alive
+    private let _drawPreview: (CGContext, CGPoint, CanvasToolContext) -> Void
+    private let _handleEscape: () -> Void
+    private let _handleBackspace: () -> Void
+    private let box: ToolBoxBase          // <— keeps the ToolBox alive
 
      init<T: CanvasTool>(_ tool: T) {
          let storage = ToolBox(tool)       // class wrapper, reference-type
@@ -25,29 +27,51 @@ struct AnyCanvasTool: CanvasTool {
          symbolName = tool.symbolName
          label      = tool.label
 
-         // ----- handleTap ----------------------------------------------------
-         _handleTap = { loc, ctx in
-             var inner = storage.tool             // 1 – copy out
-             let element = inner.handleTap(at: loc, context: ctx) // 2 – mutate
-             storage.tool = inner                 // 3 – store back
-             return element                       // 4
-         }
+        // ----- handleTap ----------------------------------------------------
+        _handleTap = { loc, ctx in
+            var inner = storage.tool             // 1 – copy out
+            let element = inner.handleTap(at: loc, context: ctx) // 2 – mutate
+            storage.tool = inner                 // 3 – store back
+            return element                       // 4
+        }
 
-         // ----- drawPreview ---------------------------------------------------
-         _drawPreview = { cgCTX, mouse, ctx in
-             var inner = storage.tool             // 1
-             inner.drawPreview(in: cgCTX, mouse: mouse, context: ctx) // 2
-             storage.tool = inner                 // 3
-         }
+        // ----- drawPreview --------------------------------------------------
+        _drawPreview = { cgCTX, mouse, ctx in
+            var inner = storage.tool             // 1
+            inner.drawPreview(in: cgCTX, mouse: mouse, context: ctx) // 2
+            storage.tool = inner                 // 3
+        }
+
+        // ----- handleEscape -------------------------------------------------
+        _handleEscape = {
+            var inner = storage.tool
+            inner.handleEscape()
+            storage.tool = inner
+        }
+
+        // ----- handleBackspace ----------------------------------------------
+        _handleBackspace = {
+            var inner = storage.tool
+            inner.handleBackspace()
+            storage.tool = inner
+        }
      }
 
      // simple forwarders -------------------------------------------------------
      mutating func handleTap(at point: CGPoint, context: CanvasToolContext) -> CanvasElement? {
          _handleTap(point, context)
      }
-     mutating func drawPreview(in cgCTX: CGContext, mouse: CGPoint, context: CanvasToolContext) {
-         _drawPreview(cgCTX, mouse, context)
-     }
+    mutating func drawPreview(in cgCTX: CGContext, mouse: CGPoint, context: CanvasToolContext) {
+        _drawPreview(cgCTX, mouse, context)
+    }
+
+    mutating func handleEscape() {
+        _handleEscape()
+    }
+
+    mutating func handleBackspace() {
+        _handleBackspace()
+    }
 
     static func == (lhs: AnyCanvasTool, rhs: AnyCanvasTool) -> Bool { lhs.id == rhs.id }
     func hash(into hasher: inout Hasher) { hasher.combine(id) }

--- a/CircuitPro/Features/Toolbar/Tool/CanvasTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/CanvasTool.swift
@@ -15,10 +15,23 @@ protocol CanvasTool: Hashable {
     mutating func handleTap(at location: CGPoint, context: CanvasToolContext) -> CanvasElement?
 
     mutating func drawPreview(in ctx: CGContext, mouse: CGPoint, context: CanvasToolContext)
+
+    // NEW: keyboard actions -------------------------------------------------
+    /// Called when the user presses the Escape key while this tool is active.
+    /// Tools can reset any in-progress state here.
+    mutating func handleEscape()
+
+    /// Called when the Backspace key is pressed. Tools should undo the most
+    /// recent step of the operation if possible.
+    mutating func handleBackspace()
 }
 
 extension CanvasTool {
     mutating func handleTap(at location: CGPoint) -> CanvasElement? {
         handleTap(at: location, context: CanvasToolContext())
     }
+
+    mutating func handleEscape() {}
+
+    mutating func handleBackspace() {}
 }

--- a/CircuitPro/Features/Toolbar/Tool/Elements/ConnectionTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Elements/ConnectionTool.swift
@@ -69,6 +69,26 @@ struct ConnectionTool: CanvasTool, Equatable, Hashable {
                 ? .vertical : .horizontal
             lastNodeID = endNode.id
         }
+
+        mutating func backtrack() {
+            guard let lastEdge = net.edges.popLast() else {
+                return
+            }
+
+            if net.edges.allSatisfy({ $0.startNodeID != lastEdge.endNodeID && $0.endNodeID != lastEdge.endNodeID }) {
+                net.nodeByID.removeValue(forKey: lastEdge.endNodeID)
+            }
+
+            lastNodeID = lastEdge.startNodeID
+
+            if let prevEdge = net.edges.last,
+               let start = net.nodeByID[prevEdge.startNodeID],
+               let end = net.nodeByID[prevEdge.endNodeID] {
+                lastOrientation = (start.point.x == end.point.x) ? .vertical : .horizontal
+            } else {
+                lastOrientation = nil
+            }
+        }
     }
 
     // MARK: - Tool Actions
@@ -153,6 +173,20 @@ struct ConnectionTool: CanvasTool, Equatable, Hashable {
 
     private mutating func clearState() {
         inProgressRoute = nil
+    }
+
+    mutating func handleEscape() {
+        clearState()
+    }
+
+    mutating func handleBackspace() {
+        guard var route = inProgressRoute else { return }
+        route.backtrack()
+        if route.net.edges.isEmpty {
+            inProgressRoute = nil
+        } else {
+            inProgressRoute = route
+        }
     }
 
     static func merge(

--- a/CircuitPro/Features/Toolbar/Tool/Graphics/CircleTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Graphics/CircleTool.swift
@@ -40,4 +40,12 @@ struct CircleTool: CanvasTool {
         ctx.strokeEllipse(in: rect)
         ctx.restoreGState()
     }
+
+    mutating func handleEscape() {
+        center = nil
+    }
+
+    mutating func handleBackspace() {
+        center = nil
+    }
 }

--- a/CircuitPro/Features/Toolbar/Tool/Graphics/LineTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Graphics/LineTool.swift
@@ -43,4 +43,12 @@ struct LineTool: CanvasTool {
         ctx.strokePath()
         ctx.restoreGState()
     }
+
+    mutating func handleEscape() {
+        start = nil
+    }
+
+    mutating func handleBackspace() {
+        start = nil
+    }
 }

--- a/CircuitPro/Features/Toolbar/Tool/Graphics/RectangleTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Graphics/RectangleTool.swift
@@ -43,4 +43,12 @@ struct RectangleTool: CanvasTool {
         ctx.stroke(rect)
         ctx.restoreGState()
     }
+
+    mutating func handleEscape() {
+        start = nil
+    }
+
+    mutating func handleBackspace() {
+        start = nil
+    }
 }

--- a/CircuitPro/Features/Toolbar/Tool/Utility/RulerTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Utility/RulerTool.swift
@@ -108,5 +108,28 @@ struct RulerTool: CanvasTool {
 
         text.draw(at: drawPoint)
     }
+    mutating func handleEscape() {
+        start = nil
+        end = nil
+        clicks = 0
+    }
+
+    mutating func handleBackspace() {
+        switch clicks {
+        case 0:
+            break
+        case 1:
+            start = nil
+            clicks = 0
+        case 2:
+            end = nil
+            clicks = 1
+        default:
+            start = nil
+            end = nil
+            clicks = 0
+        }
+    }
+
 
 }


### PR DESCRIPTION
## Summary
- add Escape and Backspace actions to the `CanvasTool` protocol
- implement delegating support in `AnyCanvasTool`
- update drawing tools and connection tool to clear or revert progress
- handle Escape/Backspace in ruler tool
- process Escape/Backspace events in `CoreGraphicsCanvasView`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d2823ce98832f9f3c6380a75de1fa