### PR TITLE
Restore connection segment deletion

### DIFF
--- a/CircuitPro/Features/Canvas/AppKit/CoreGraphicsCanvasView.swift
+++ b/CircuitPro/Features/Canvas/AppKit/CoreGraphicsCanvasView.swift
@@ -147,17 +147,22 @@ final class CoreGraphicsCanvasView: NSView {
 
         var out: [CanvasElement] = []
 
-        for var element in elements {
+        for element in elements {
 
             switch element {
 
-            // 1 ─ connection: strip only the selected segments
-//            case .connection(var conn):
-//                conn.segments.removeAll { seg in selectedIDs.contains(seg.id) }
-//                if !conn.segments.isEmpty {          // keep non-empty tracks
-//                    element = .connection(conn)
-//                    out.append(element)
-//                }
+            // 1 ─ connections: remove only the selected segments
+            case .connection(let conn):
+                // If the entire connection is selected, drop it completely.
+                guard !selectedIDs.contains(conn.id) else { continue }
+
+                let edgeIDs = Set(conn.net.edges.compactMap { selectedIDs.contains($0.id) ? $0.id : nil })
+                if edgeIDs.isEmpty {
+                    out.append(element)
+                } else {
+                    let nets = conn.net.deletingEdges(withIDs: edgeIDs)
+                    out.append(contentsOf: nets.map { .connection(ConnectionElement(id: $0.id, net: $0)) })
+                }
 
             // 2 ─ anything else: drop the whole object when its id is selected
             default:

--- a/CircuitPro/Features/_Temp/Connection/Algorithms/Net+Delete.swift
+++ b/CircuitPro/Features/_Temp/Connection/Algorithms/Net+Delete.swift
@@ -1,0 +1,64 @@
+//
+//  Net+Delete.swift
+//  CircuitPro
+//
+//  Created by Codex
+//
+
+import Foundation
+
+extension Net {
+    /// Returns new nets after removing the edges whose IDs are in `edgeIDs`.
+    /// Any orphaned nodes are discarded and the resulting nets are split into
+    /// connected components.
+    func deletingEdges(withIDs edgeIDs: Set<UUID>) -> [Net] {
+        let remainingEdges = edges.filter { !edgeIDs.contains($0.id) }
+        guard !remainingEdges.isEmpty else { return [] }
+
+        var usedNodeIDs = Set<UUID>()
+        for edge in remainingEdges {
+            usedNodeIDs.insert(edge.startNodeID)
+            usedNodeIDs.insert(edge.endNodeID)
+        }
+        let remainingNodes = nodeByID.filter { usedNodeIDs.contains($0.key) }
+        let baseNet = Net(id: UUID(), nodeByID: remainingNodes, edges: remainingEdges)
+        return baseNet.connectedComponents()
+    }
+
+    /// Splits the net into connected components.
+    func connectedComponents() -> [Net] {
+        var visitedNodes = Set<UUID>()
+        var components: [Net] = []
+
+        for nodeID in nodeByID.keys {
+            guard !visitedNodes.contains(nodeID) else { continue }
+
+            var stack: [UUID] = [nodeID]
+            var nodeSet = Set<UUID>()
+            var edgeSet = Set<UUID>()
+            visitedNodes.insert(nodeID)
+
+            while let current = stack.popLast() {
+                nodeSet.insert(current)
+                for edge in edges where edge.startNodeID == current || edge.endNodeID == current {
+                    if !edgeSet.contains(edge.id) {
+                        edgeSet.insert(edge.id)
+                        let neighbor = (edge.startNodeID == current) ? edge.endNodeID : edge.startNodeID
+                        if !visitedNodes.contains(neighbor) {
+                            visitedNodes.insert(neighbor)
+                            stack.append(neighbor)
+                        }
+                    }
+                }
+            }
+
+            var nodes: [UUID: Node] = [:]
+            for id in nodeSet { nodes[id] = nodeByID[id] }
+            let compEdges = edges.filter { edgeSet.contains($0.id) }
+            components.append(Net(id: UUID(), nodeByID: nodes, edges: compEdges))
+        }
+
+        return components
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `Net.deletingEdges` and `connectedComponents` helpers
- support deleting individual connection segments in `CoreGraphicsCanvasView`

## Testing
- `No tests run`

------
https://chatgpt.com/codex/tasks/task_e_686d2d229ee4832faf5c8795a9f00dae