### PR TITLE
Introduce generic CanvasLayer

### DIFF
--- a/CircuitPro/Features/Canvas/AppKit/CoreGraphicsCanvasView.swift
+++ b/CircuitPro/Features/Canvas/AppKit/CoreGraphicsCanvasView.swift
@@ -20,7 +20,7 @@ final class CoreGraphicsCanvasView: NSView {
 
     var onUpdate: (([CanvasElement]) -> Void)?
     var onSelectionChange: ((Set<UUID>) -> Void)?
-    var onPrimitiveAdded: ((UUID, LayerKind) -> Void)?
+    var onPrimitiveAdded: ((UUID, CanvasLayer) -> Void)?
     var onMouseMoved: ((CGPoint) -> Void)?
 
     private(set) var hoveredPinID: UUID? {
@@ -39,7 +39,7 @@ final class CoreGraphicsCanvasView: NSView {
     private lazy var hitTesting = CanvasHitTestController(canvas: self)
 
     var selectedTool: AnyCanvasTool?
-    var selectedLayer: LayerKind = .copper
+    var selectedLayer: CanvasLayer = .layer0
 
     override var isFlipped: Bool { true }
 

--- a/CircuitPro/Features/Canvas/Model/CanvasLayerBindings.swift
+++ b/CircuitPro/Features/Canvas/Model/CanvasLayerBindings.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+/// Wrapper for layer-related bindings passed to ``CanvasView``.
+struct CanvasLayerBindings {
+    var selectedLayer: Binding<CanvasLayer?>
+    var layerAssignments: Binding<[UUID: CanvasLayer]>
+}

--- a/CircuitPro/Features/ComponentDesign/Footprint/FootprintDesignView.swift
+++ b/CircuitPro/Features/ComponentDesign/Footprint/FootprintDesignView.swift
@@ -20,8 +20,10 @@ struct FootprintDesignView: View {
             elements: $bindableComponentDesignManager.footprintElements,
             selectedIDs: $bindableComponentDesignManager.selectedFootprintElementIDs,
             selectedTool: $bindableComponentDesignManager.selectedFootprintTool,
-            selectedLayer: $bindableComponentDesignManager.selectedFootprintLayer,
-            layerAssignments: $bindableComponentDesignManager.layerAssignments
+            layerBindings: CanvasLayerBindings(
+                selectedLayer: $bindableComponentDesignManager.selectedFootprintLayer,
+                layerAssignments: $bindableComponentDesignManager.layerAssignments
+            )
         )
         .clipAndStroke(with: .rect(cornerRadius: 20))
         .overlay {

--- a/CircuitPro/Features/ComponentDesign/Footprint/LayerTypeListView.swift
+++ b/CircuitPro/Features/ComponentDesign/Footprint/LayerTypeListView.swift
@@ -19,10 +19,22 @@ struct LayerTypeListView: View {
             Text("Layers")
                 .font(.headline)
         } content: {
+            // Bridge ``CanvasLayer`` selection with the list of ``LayerKind`` values.
+            let selection = Binding<LayerKind?>(
+                get: { bindableComponentDesignManager.selectedFootprintLayer?.kind },
+                set: { newValue in
+                    if let newValue {
+                        bindableComponentDesignManager.selectedFootprintLayer = CanvasLayer(kind: newValue)
+                    } else {
+                        bindableComponentDesignManager.selectedFootprintLayer = nil
+                    }
+                }
+            )
+
             List(
                 LayerKind.footprintLayers,
                 id: \.self,
-                selection: $bindableComponentDesignManager.selectedFootprintLayer
+                selection: selection
             ) { layerType in
                         HStack {
                             Image(systemName: "circle.fill")

--- a/CircuitPro/Features/ComponentDesign/Symbol/SymbolDesignView.swift
+++ b/CircuitPro/Features/ComponentDesign/Symbol/SymbolDesignView.swift
@@ -17,8 +17,7 @@ struct SymbolDesignView: View {
             elements: $bindableComponentDesignManager.symbolElements,
             selectedIDs: $bindableComponentDesignManager.selectedSymbolElementIDs,
             selectedTool: $bindableComponentDesignManager.selectedSymbolTool,
-            selectedLayer: .constant(.copper),
-            layerAssignments: .constant([.init(): .copper])
+            layerBindings: nil
         )
         .clipAndStroke(with: .rect(cornerRadius: 20))
         .overlay {

--- a/CircuitPro/Features/Editor/SchematicView.swift
+++ b/CircuitPro/Features/Editor/SchematicView.swift
@@ -15,8 +15,8 @@ struct SchematicView: View {
     @State private var selectedIDs: Set<UUID> = []
     @State private var selectedTool: AnyCanvasTool = .init(CursorTool())
 
-    @State private var selectedLayer: LayerKind?
-    @State private var layerAssignments: [UUID: LayerKind] = [:]
+    @State private var selectedLayer: CanvasLayer?
+    @State private var layerAssignments: [UUID: CanvasLayer] = [:]
 
     @State private var debugString: String?
 
@@ -26,8 +26,10 @@ struct SchematicView: View {
             elements: $canvasElements,
             selectedIDs: $selectedIDs,
             selectedTool: $selectedTool,
-            selectedLayer: $selectedLayer,
-            layerAssignments: $layerAssignments
+            layerBindings: CanvasLayerBindings(
+                selectedLayer: $selectedLayer,
+                layerAssignments: $layerAssignments
+            )
         )
         .dropDestination(for: TransferableComponent.self) { dropped, loc in
             addComponents(dropped, atClipPoint: loc)

--- a/CircuitPro/Features/Toolbar/Tool/CanvasToolContext.swift
+++ b/CircuitPro/Features/Toolbar/Tool/CanvasToolContext.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CanvasToolContext {
     var existingPinCount: Int = 0
     var existingPadCount: Int = 0
-    var selectedLayer: LayerKind = .copper
+    var selectedLayer: CanvasLayer = .layer0
     var magnification: CGFloat = 1.0
     var hitSegmentID: UUID?
 }

--- a/CircuitPro/Features/Toolbar/Tool/Graphics/CircleTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Graphics/CircleTool.swift
@@ -17,7 +17,7 @@ struct CircleTool: CanvasTool {
                 position: center,
                 rotation: 0,
                 strokeWidth: 1,
-                color: .init(color: context.selectedLayer.defaultColor),
+                color: .init(color: context.selectedLayer.color),
                 filled: false
             )
             self.center = nil
@@ -34,7 +34,7 @@ struct CircleTool: CanvasTool {
         let rect = CGRect(x: center.x - radius, y: center.y - radius, width: radius * 2, height: radius * 2)
 
         ctx.saveGState()
-        ctx.setStrokeColor(NSColor(context.selectedLayer.defaultColor).cgColor)
+        ctx.setStrokeColor(NSColor(context.selectedLayer.color).cgColor)
         ctx.setLineWidth(1)
         ctx.setLineDash(phase: 0, lengths: [4])
         ctx.strokeEllipse(in: rect)

--- a/CircuitPro/Features/Toolbar/Tool/Graphics/LineTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Graphics/LineTool.swift
@@ -23,7 +23,7 @@ struct LineTool: CanvasTool {
                 end: location,
                 rotation: 0,
                 strokeWidth: 1,
-                color: .init(color: context.selectedLayer.defaultColor)
+                color: .init(color: context.selectedLayer.color)
             )
             return .primitive(.line(line))
         } else {
@@ -35,7 +35,7 @@ struct LineTool: CanvasTool {
     mutating func drawPreview(in ctx: CGContext, mouse: CGPoint, context: CanvasToolContext) {
         guard let start else { return }
         ctx.saveGState()
-        ctx.setStrokeColor(NSColor(context.selectedLayer.defaultColor).cgColor)
+        ctx.setStrokeColor(NSColor(context.selectedLayer.color).cgColor)
         ctx.setLineWidth(1)
         ctx.setLineDash(phase: 0, lengths: [4])
         ctx.move(to: start)

--- a/CircuitPro/Features/Toolbar/Tool/Graphics/RectangleTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Graphics/RectangleTool.swift
@@ -22,7 +22,7 @@ struct RectangleTool: CanvasTool {
                 rotation: 0,
                 strokeWidth: 1,
                 filled: false,
-                color: .init(color: context.selectedLayer.defaultColor)
+                color: .init(color: context.selectedLayer.color)
             )
             self.start = nil
             return .primitive(.rectangle(rectangle))
@@ -37,7 +37,7 @@ struct RectangleTool: CanvasTool {
         let rect = CGRect(origin: start, size: .zero).union(CGRect(origin: mouse, size: .zero))
 
         ctx.saveGState()
-        ctx.setStrokeColor(NSColor(context.selectedLayer.defaultColor).cgColor)
+        ctx.setStrokeColor(NSColor(context.selectedLayer.color).cgColor)
         ctx.setLineWidth(1)
         ctx.setLineDash(phase: 0, lengths: [4])
         ctx.stroke(rect)

--- a/CircuitPro/Managers/ComponentDesignManager.swift
+++ b/CircuitPro/Managers/ComponentDesignManager.swift
@@ -27,8 +27,8 @@ final class ComponentDesignManager {
     var selectedFootprintElementIDs: Set<UUID> = []
     var selectedFootprintTool: AnyCanvasTool = AnyCanvasTool(CursorTool())
 
-    var selectedFootprintLayer: LayerKind? = .copper
-    var layerAssignments: [UUID: LayerKind] = [:]
+    var selectedFootprintLayer: CanvasLayer? = .layer0
+    var layerAssignments: [UUID: CanvasLayer] = [:]
 
     // MARK: - Reset All State
     func resetAll() {
@@ -50,7 +50,7 @@ final class ComponentDesignManager {
         footprintElements = []
         selectedFootprintElementIDs = []
         selectedFootprintTool = AnyCanvasTool(CursorTool())
-        selectedFootprintLayer = .copper
+        selectedFootprintLayer = .layer0
         layerAssignments = [:]
     }
 

--- a/CircuitPro/Model/Layers/CanvasLayer.swift
+++ b/CircuitPro/Model/Layers/CanvasLayer.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Generic layer description used by ``CanvasView``.
+/// When no specific layer information is supplied, ``layer0`` is used.
+struct CanvasLayer: Hashable {
+    /// Z position in the stack (0 is bottom)
+    var zPosition: Int
+    /// Display color for primitives placed on this layer
+    var color: Color
+    /// Optional PCB-specific kind when applicable
+    var kind: LayerKind?
+
+    init(zPosition: Int, color: Color = .gray, kind: LayerKind? = nil) {
+        self.zPosition = zPosition
+        self.color = color
+        self.kind = kind
+    }
+}
+
+extension CanvasLayer {
+    /// Default layer used when no layering information is provided.
+    static let layer0 = CanvasLayer(zPosition: 0)
+
+    /// Convenience initializer to build a ``CanvasLayer`` from ``LayerKind``.
+    init(kind: LayerKind) {
+        self.init(zPosition: 0, color: kind.defaultColor, kind: kind)
+    }
+}

--- a/CircuitPro/Model/Layers/CanvasLayer.swift
+++ b/CircuitPro/Model/Layers/CanvasLayer.swift
@@ -3,15 +3,15 @@ import SwiftUI
 /// Generic layer description used by ``CanvasView``.
 /// When no specific layer information is supplied, ``layer0`` is used.
 struct CanvasLayer: Hashable {
-    /// Z position in the stack (0 is bottom)
-    var zPosition: Int
+    /// Z-index in the stack (0 is bottom)
+    var zIndex: Int
     /// Display color for primitives placed on this layer
     var color: Color
     /// Optional PCB-specific kind when applicable
     var kind: LayerKind?
 
-    init(zPosition: Int, color: Color = .gray, kind: LayerKind? = nil) {
-        self.zPosition = zPosition
+    init(zIndex: Int, color: Color = .gray, kind: LayerKind? = nil) {
+        self.zIndex = zIndex
         self.color = color
         self.kind = kind
     }
@@ -19,10 +19,10 @@ struct CanvasLayer: Hashable {
 
 extension CanvasLayer {
     /// Default layer used when no layering information is provided.
-    static let layer0 = CanvasLayer(zPosition: 0)
+    static let layer0 = CanvasLayer(zIndex: 0)
 
     /// Convenience initializer to build a ``CanvasLayer`` from ``LayerKind``.
     init(kind: LayerKind) {
-        self.init(zPosition: 0, color: kind.defaultColor, kind: kind)
+        self.init(zIndex: kind.zIndex, color: kind.defaultColor, kind: kind)
     }
 }

--- a/CircuitPro/Model/Layers/LayerKind.swift
+++ b/CircuitPro/Model/Layers/LayerKind.swift
@@ -59,6 +59,22 @@ extension LayerKind {
 }
 
 extension LayerKind {
+    /// Default z-index used when converting to ``CanvasLayer``.
+    var zIndex: Int {
+        switch self {
+        case .boardOutline: return 0
+        case .copper, .innerCopper: return 1
+        case .solderMask: return 2
+        case .paste: return 3
+        case .silkscreen: return 4
+        case .adhesive: return 5
+        case .courtyard: return 6
+        case .fabrication: return 7
+        }
+    }
+}
+
+extension LayerKind {
     /// Layer kinds that are used in footprint creation
     static var footprintLayers: [LayerKind] {
         return [


### PR DESCRIPTION
## Summary
- add general `CanvasLayer` model with default `layer0`
- carry optional layer bindings using `CanvasLayer`
- bridge footprint layer selection to this new type
- update canvas tools and views to work with `CanvasLayer`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d28c43604832f8544260b45be756d