### PR TITLE
Add rotate hotkey for pins and pads

### DIFF
--- a/CircuitPro/Features/Canvas/AppKit/CoreGraphicsCanvasView.swift
+++ b/CircuitPro/Features/Canvas/AppKit/CoreGraphicsCanvasView.swift
@@ -128,8 +128,12 @@ final class CoreGraphicsCanvasView: NSView {
 
         switch key {
         case "r":
-            if let id = selectedIDs.first,
-               let center = elements.first(where: { $0.id == id })?.primitives.first?.position {
+            if var tool = selectedTool, tool.id != "cursor" {
+                tool.handleRotate()
+                selectedTool = tool
+                needsDisplay = true
+            } else if let id = selectedIDs.first,
+                      let center = elements.first(where: { $0.id == id })?.primitives.first?.position {
                 interaction.enterRotationMode(around: center)
             }
 

--- a/CircuitPro/Features/Toolbar/Tool/AnyCanvasTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/AnyCanvasTool.swift
@@ -17,6 +17,7 @@ struct AnyCanvasTool: CanvasTool {
     private let _drawPreview: (CGContext, CGPoint, CanvasToolContext) -> Void
     private let _handleEscape: () -> Void
     private let _handleBackspace: () -> Void
+    private let _handleRotate: () -> Void
     private let box: ToolBoxBase          // <— keeps the ToolBox alive
 
      init<T: CanvasTool>(_ tool: T) {
@@ -55,6 +56,13 @@ struct AnyCanvasTool: CanvasTool {
             inner.handleBackspace()
             storage.tool = inner
         }
+
+        // ----- handleRotate -------------------------------------------------
+        _handleRotate = {
+            var inner = storage.tool
+            inner.handleRotate()
+            storage.tool = inner
+        }
      }
 
      // simple forwarders -------------------------------------------------------
@@ -71,6 +79,10 @@ struct AnyCanvasTool: CanvasTool {
 
     mutating func handleBackspace() {
         _handleBackspace()
+    }
+
+    mutating func handleRotate() {
+        _handleRotate()
     }
 
     static func == (lhs: AnyCanvasTool, rhs: AnyCanvasTool) -> Bool { lhs.id == rhs.id }

--- a/CircuitPro/Features/Toolbar/Tool/CanvasTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/CanvasTool.swift
@@ -24,6 +24,10 @@ protocol CanvasTool: Hashable {
     /// Called when the Backspace key is pressed. Tools should undo the most
     /// recent step of the operation if possible.
     mutating func handleBackspace()
+
+    /// Called when the R key is pressed. Tools can use this to cycle through
+    /// discrete rotation states or otherwise adjust orientation.
+    mutating func handleRotate()
 }
 
 extension CanvasTool {
@@ -34,4 +38,6 @@ extension CanvasTool {
     mutating func handleEscape() {}
 
     mutating func handleBackspace() {}
+
+    mutating func handleRotate() {}
 }

--- a/CircuitPro/Features/Toolbar/Tool/Elements/PadTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Elements/PadTool.swift
@@ -12,11 +12,14 @@ struct PadTool: CanvasTool {
     let symbolName = CircuitProSymbols.Footprint.pad
     let label = "Pad"
 
+    private var rotation: CardinalRotation = .deg0
+
     mutating func handleTap(at location: CGPoint, context: CanvasToolContext) -> CanvasElement? {
         let number = context.existingPadCount + 1
         let pad = Pad(
             number: number,
             position: location,
+            cardinalRotation: rotation,
             shape: .rect(width: 5, height: 10),
             type: .surfaceMount,
             drillDiameter: nil
@@ -29,11 +32,19 @@ struct PadTool: CanvasTool {
         let previewPad = Pad(
             number: number,
             position: mouse,
+            cardinalRotation: rotation,
             shape: .rect(width: 5, height: 10),
             type: .surfaceMount,
             drillDiameter: nil
         )
 
         previewPad.draw(in: ctx, selected: false)
+    }
+
+    mutating func handleRotate() {
+        let all = CardinalRotation.allCases
+        if let idx = all.firstIndex(of: rotation) {
+            rotation = all[(idx + 1) % all.count]
+        }
     }
 }

--- a/CircuitPro/Features/Toolbar/Tool/Elements/PinTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Elements/PinTool.swift
@@ -13,12 +13,15 @@ struct PinTool: CanvasTool {
     let symbolName = CircuitProSymbols.Symbol.pin
     let label = "Pin"
 
+    private var rotation: CardinalRotation = .deg0
+
     mutating func handleTap(at location: CGPoint, context: CanvasToolContext) -> CanvasElement? {
         let number = context.existingPinCount + 1
         let pin = Pin(
             name: "",
             number: number,
             position: location,
+            cardinalRotation: rotation,
             type: .unknown,
             lengthType: .long
         )
@@ -30,6 +33,7 @@ struct PinTool: CanvasTool {
             name: "",
             number: context.existingPinCount + 1,
             position: mouse,
+            cardinalRotation: rotation,
             type: .unknown,
             lengthType: .long
         )
@@ -38,5 +42,12 @@ struct PinTool: CanvasTool {
             in: ctx,
             selected: false     // no selection halo for preview
         )
+    }
+
+    mutating func handleRotate() {
+        let all = CardinalRotation.allCases
+        if let idx = all.firstIndex(of: rotation) {
+            rotation = all[(idx + 1) % all.count]
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow canvas tools to respond to rotate events
- handle rotate in `AnyCanvasTool`
- track rotation inside `PinTool` and `PadTool`
- rotate pin and pad tools with the **R** key in `CoreGraphicsCanvasView`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d3876e06c832f85569da550a64954