### PR TITLE
Add numeric shortcuts for canvas tools

### DIFF
--- a/CircuitPro/Features/Toolbar/ToolbarView.swift
+++ b/CircuitPro/Features/Toolbar/ToolbarView.swift
@@ -63,6 +63,8 @@ struct ToolbarView<Tool: CanvasTool>: View {
     }
 
     private func toolbarButton(_ tool: Tool) -> some View {
+        let index = tools.firstIndex(of: tool) ?? 0
+
         Button {
             selectedTool = tool
             onToolSelected(tool)
@@ -72,7 +74,12 @@ struct ToolbarView<Tool: CanvasTool>: View {
                 .frame(width: 22, height: 22)
                 .foregroundStyle(selectedTool == tool ? .blue : .secondary)
         }
-        // TODO: Add shortcuts
-        .help("\(tool.label) Tool\nShortcut:")
+        .if(index < 9) { view in
+            view.keyboardShortcut(
+                KeyEquivalent(Character(String(index + 1))),
+                modifiers: []
+            )
+        }
+        .help("\(tool.label) Tool\nShortcut: \(index + 1)")
     }
 }

--- a/CircuitPro/Features/Toolbar/ToolbarView.swift
+++ b/CircuitPro/Features/Toolbar/ToolbarView.swift
@@ -65,7 +65,7 @@ struct ToolbarView<Tool: CanvasTool>: View {
     private func toolbarButton(_ tool: Tool) -> some View {
         let index = tools.firstIndex(of: tool) ?? 0
 
-        Button {
+        return Button {
             selectedTool = tool
             onToolSelected(tool)
         } label: {


### PR DESCRIPTION
## Summary
- enable keyboard shortcuts for the tool palette
- show the shortcut hint in tooltips

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686d6359b3bc832f9cd6c9f63dac40d9