### PR TITLE
Refactor connection routing layer

### DIFF
--- a/CircuitPro/Features/Toolbar/Tool/Elements/ConnectionTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Elements/ConnectionTool.swift
@@ -1,319 +1,56 @@
-//
-//  ConnectionTool.swift
-//  CircuitPro
-//
-//  Updated 02 Jul 2025
-//
-
 import SwiftUI
 import AppKit
 
-/// Orientation of the last segment: used to flip elbow order in routing strategies.
-fileprivate enum RoutingOrientation {
-    case horizontal, vertical
-}
-
-/// Strategy for computing bend points between two coordinates.
-fileprivate protocol RoutingStrategy {
-    /// Returns the sequence of intermediate points (excluding the start point) to connect `start` to `end`,
-    /// taking into account the previous segment's orientation.
-    func route(from start: CGPoint, to end: CGPoint, lastOrientation: RoutingOrientation?) -> [CGPoint]
-}
-
-/// Default Manhattan (orthogonal elbow) routing: horizontal vs vertical first.
-fileprivate struct ManhattanRoutingStrategy: RoutingStrategy {
-    func route(from start: CGPoint, to end: CGPoint, lastOrientation: RoutingOrientation?) -> [CGPoint] {
-        // Insert an elbow if both coordinates differ
-        if start.x != end.x && start.y != end.y {
-            let firstIsVertical = (lastOrientation == .horizontal)
-            let elbow = firstIsVertical
-                ? CGPoint(x: start.x, y: end.y)
-                : CGPoint(x: end.x, y: start.y)
-            return [elbow, end]
-        }
-        // Straight segment
-        return [end]
-    }
-}
-
 struct ConnectionTool: CanvasTool, Equatable, Hashable {
-
     let id = "connection"
     let symbolName = CircuitProSymbols.Graphic.line
     let label = "Connection"
 
-    // The entire state of the route-in-progress is held here.
-    // It's nil when the tool is idle.
-    private var inProgressRoute: RouteInProgress?
+    private let controller: ConnectionController
 
-    // MARK: - RouteInProgress (The brains of the operation)
-    /// A private helper struct that manages the construction of a new Net while the user clicks around the canvas.
-    private struct RouteInProgress: Equatable, Hashable {
-        var net: Net
-        let startNodeID: UUID
-        var lastNodeID: UUID
-        private(set) var lastOrientation: RoutingOrientation?
-        let strategy: RoutingStrategy
-
-        init(startPoint: CGPoint, connectingTo existingElementID: UUID?, strategy: RoutingStrategy) {
-            let startNode = Node(id: UUID(), point: startPoint, kind: .endpoint)
-            self.net = Net(id: UUID(), nodeByID: [startNode.id: startNode], edges: [])
-            self.startNodeID = startNode.id
-            self.lastNodeID = startNode.id
-            self.strategy = strategy
-        }
-
-        // MARK: - Extend Logic (delegates to routing strategy)
-        mutating func extend(to point: CGPoint, connectingTo existingNodeID: UUID? = nil) {
-            guard let lastNode = net.nodeByID[lastNodeID] else { return }
-
-            // Compute bend points (including final) via strategy
-            let bendPoints = strategy.route(from: lastNode.point, to: point, lastOrientation: lastOrientation)
-
-            // Create intermediate bends
-            for bend in bendPoints.dropLast() {
-                let bendNode = Node(id: UUID(), point: bend, kind: .endpoint)
-                net.nodeByID[bendNode.id] = bendNode
-                net.edges.append(Edge(id: UUID(), startNodeID: lastNodeID, endNodeID: bendNode.id))
-                // Update orientation for this segment
-                lastOrientation = (bend.x == lastNode.point.x) ? .vertical : .horizontal
-                lastNodeID = bendNode.id
-            }
-
-            // Final segment (possibly reusing existing node)
-            let finalPoint = bendPoints.last!
-            let endID: UUID
-            if let existing = existingNodeID {
-                endID = existing
-            } else {
-                let endNode = Node(id: UUID(), point: finalPoint, kind: .endpoint)
-                net.nodeByID[endNode.id] = endNode
-                endID = endNode.id
-            }
-            net.edges.append(Edge(id: UUID(), startNodeID: lastNodeID, endNodeID: endID))
-            lastOrientation = (finalPoint.x == net.nodeByID[lastNodeID]!.point.x) ? .vertical : .horizontal
-            lastNodeID = endID
-        }
-
-        mutating func backtrack() {
-            guard let lastEdge = net.edges.popLast() else {
-                return
-            }
-
-            if net.edges.allSatisfy({ $0.startNodeID != lastEdge.endNodeID && $0.endNodeID != lastEdge.endNodeID }) {
-                net.nodeByID.removeValue(forKey: lastEdge.endNodeID)
-            }
-
-            lastNodeID = lastEdge.startNodeID
-
-            if let prevEdge = net.edges.last,
-               let start = net.nodeByID[prevEdge.startNodeID],
-               let end = net.nodeByID[prevEdge.endNodeID] {
-                lastOrientation = (start.point.x == end.point.x) ? .vertical : .horizontal
-            } else {
-                lastOrientation = nil
-            }
-        }
-
-        // MARK: - Equatable & Hashable (ignoring strategy)
-        static func == (lhs: RouteInProgress, rhs: RouteInProgress) -> Bool {
-            lhs.net == rhs.net
-            && lhs.startNodeID == rhs.startNodeID
-            && lhs.lastNodeID == rhs.lastNodeID
-            && lhs.lastOrientation == rhs.lastOrientation
-        }
-
-        func hash(into hasher: inout Hasher) {
-            hasher.combine(net)
-            hasher.combine(startNodeID)
-            hasher.combine(lastNodeID)
-            hasher.combine(lastOrientation)
-        }
+    init(controller: ConnectionController = ConnectionController(repository: NetRepository())) {
+        self.controller = controller
     }
 
-    // MARK: - Tool Actions
     mutating func handleTap(at loc: CGPoint, context: CanvasToolContext) -> CanvasElement? {
-        // 1. On the first tap, we begin a new route.
-        if inProgressRoute == nil {
-            inProgressRoute = RouteInProgress(
-                startPoint: loc,
-                connectingTo: context.hitSegmentID,
-                strategy: ManhattanRoutingStrategy()
-            )
-            return nil
-        }
-
-        var targetNodeID: UUID? = nil
-        var shouldFinish = false
-
-        let lastNodeID = inProgressRoute!.lastNodeID
-        let hitNodeID = inProgressRoute?.net.nodeID(at: loc)
-
-        if let nodeID = hitNodeID, nodeID != lastNodeID {
-            if var node = inProgressRoute?.net.nodeByID[nodeID] {
-                node.kind = .junction
-                inProgressRoute?.net.nodeByID[nodeID] = node
-            }
-            targetNodeID = nodeID
-            shouldFinish = true
-        } else if hitNodeID == nil,
-                  let edgeID = inProgressRoute?.net.edgeID(containing: loc),
-                  let newID = inProgressRoute?.net.splitEdge(withID: edgeID, at: loc) {
-            // Only suppress junction dot if splitting at the route's start or end point
-            if let route = inProgressRoute,
-               let splitNode = route.net.nodeByID[newID] {
-                let tol: CGFloat = 0.5
-                let startPt = route.net.nodeByID[route.startNodeID]?.point
-                let endPt = route.net.nodeByID[route.lastNodeID]?.point
-                if (startPt != nil && abs(splitNode.point.x - startPt!.x) < tol && abs(splitNode.point.y - startPt!.y) < tol)
-                    || (endPt != nil && abs(splitNode.point.x - endPt!.x) < tol && abs(splitNode.point.y - endPt!.y) < tol) {
-                    var node = splitNode
-                    node.kind = .endpoint
-                    inProgressRoute?.net.nodeByID[newID] = node
-                }
-            }
-            targetNodeID = newID
-            shouldFinish = true
-        }
-
-        // 2. On a double-tap, finish the route.
-        if let lastPoint = inProgressRoute?.net.nodeByID[lastNodeID]?.point,
-           isDoubleTap(from: lastPoint, to: loc) {
-            if hitNodeID == lastNodeID {
-                return finishRoute()
-            }
-            inProgressRoute?.extend(to: loc, connectingTo: targetNodeID)
-            return finishRoute()
-        }
-
-        inProgressRoute?.extend(to: loc, connectingTo: targetNodeID)
-
-        if shouldFinish {
-            return finishRoute()
-        }
-
-        // 4. If this tap landed on another wire, finish the route automatically.
-        if context.hitSegmentID != nil {
-            return finishRoute()
-        }
-
-        return nil
+        controller.handleTap(at: loc, context: context)
     }
 
     mutating func drawPreview(in ctx: CGContext, mouse: CGPoint, context: CanvasToolContext) {
-        guard let route = inProgressRoute,
-              let lastNode = route.net.nodeByID[route.lastNodeID] else { return }
-
-        ctx.saveGState()
-        ctx.setStrokeColor(NSColor(.blue).cgColor)
-        ctx.setLineWidth(1)
-
-        // 2.1 Already-fixed segments
-        for edge in route.net.edges {
-            guard let nodeA = route.net.nodeByID[edge.startNodeID],
-                  let nodeB = route.net.nodeByID[edge.endNodeID] else { continue }
-            ctx.move(to: nodeA.point)
-            ctx.addLine(to: nodeB.point)
-        }
-        ctx.strokePath()
-
-        // 2.2 Ghost segment (respect flip rule)
-        ctx.setLineDash(phase: 0, lengths: [4])
-        let startPoint = lastNode.point
-
-        if startPoint.x != mouse.x && startPoint.y != mouse.y {
-            let firstSegmentIsVertical = (route.lastOrientation == .horizontal)
-            let elbowPoint = firstSegmentIsVertical
-                ? CGPoint(x: startPoint.x, y: mouse.y)
-                : CGPoint(x: mouse.x, y: startPoint.y)
-
-            ctx.move(to: startPoint)
-            ctx.addLine(to: elbowPoint)
-            ctx.addLine(to: mouse)
-        } else {
-            ctx.move(to: startPoint)
-            ctx.addLine(to: mouse)
-        }
-
-        ctx.strokePath()
-        ctx.restoreGState()
+        controller.drawPreview(in: ctx, mouse: mouse, context: context)
     }
 
-    /// Finalizes the route, packages it into a ConnectionElement, and clears the tool's state.
-    private mutating func finishRoute() -> CanvasElement? {
-        guard var route = inProgressRoute, !route.net.edges.isEmpty else {
-            clearState()
-            return nil
-        }
-
-        // 1. Merge colinear segments inside this single route.
-        route.net.mergeColinearEdges()
-
-        // 2. Wrap and return.
-        let element = ConnectionElement(id: route.net.id, net: route.net)
-        clearState()
-        return .connection(element)
-    }
-
-    private mutating func clearState() {
-        inProgressRoute = nil
-    }
-
-    mutating func handleEscape() {
-        clearState()
-    }
-
-    mutating func handleBackspace() {
-        guard var route = inProgressRoute else { return }
-        route.backtrack()
-        if route.net.edges.isEmpty {
-            inProgressRoute = nil
-        } else {
-            inProgressRoute = route
-        }
-    }
+    mutating func handleEscape() { controller.handleEscape() }
+    mutating func handleBackspace() { controller.handleBackspace() }
 
     static func merge(
         _ newElement: ConnectionElement,
         into elements: inout [CanvasElement]
     ) -> ConnectionElement {
-
         var masterNet = newElement.net
-
         for index in (0..<elements.count).reversed() {
             guard case .connection(let existingConnection) = elements[index],
                   existingConnection.id != newElement.id else { continue }
-
             var existingNet = existingConnection.net
-
             let wasMerged = Net.findAndMergeIntentionalIntersections(
                 between: &masterNet,
                 and: &existingNet
             )
-
             if wasMerged {
-                masterNet.nodeByID.merge(existingNet.nodeByID) { currentNode, _ in currentNode }
+                masterNet.nodeByID.merge(existingNet.nodeByID) { current, _ in current }
                 masterNet.edges.append(contentsOf: existingNet.edges)
                 elements.remove(at: index)
             }
         }
-
         masterNet.mergeColinearEdges()
         return ConnectionElement(id: masterNet.id, net: masterNet)
     }
 
-    // MARK: - Helpers & Conformance
-    private func isDoubleTap(from firstPoint: CGPoint, to secondPoint: CGPoint) -> Bool {
-        // A simple distance check is sufficient for detecting a double-tap.
-        hypot(firstPoint.x - secondPoint.x, firstPoint.y - secondPoint.y) < 5
-    }
-
     static func == (lhs: ConnectionTool, rhs: ConnectionTool) -> Bool {
-        lhs.id == rhs.id && lhs.inProgressRoute == rhs.inProgressRoute
+        lhs.id == rhs.id
     }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
-        hasher.combine(inProgressRoute)
     }
 }

--- a/CircuitPro/Routing/ConnectionController.swift
+++ b/CircuitPro/Routing/ConnectionController.swift
@@ -1,0 +1,111 @@
+import CoreGraphics
+import AppKit
+
+final class ConnectionController {
+    private let repository: NetRepository
+    private let builder = RouteBuilder()
+
+    init(repository: NetRepository) {
+        self.repository = repository
+    }
+
+    func handleTap(at loc: CGPoint, context: CanvasToolContext) -> CanvasElement? {
+        if builder.snapshot == nil {
+            builder.start(at: loc, connectingTo: context.hitSegmentID)
+            return nil
+        }
+
+        guard var route = builder.snapshot else { return nil }
+        var targetNodeID: UUID? = nil
+        var shouldFinish = false
+
+        let lastNodeID = route.lastNodeID
+        let hitNodeID = route.net.nodeID(at: loc)
+
+        if let nodeID = hitNodeID, nodeID != lastNodeID {
+            if var node = route.net.nodeByID[nodeID] {
+                node.kind = .junction
+                route.net.nodeByID[nodeID] = node
+            }
+            targetNodeID = nodeID
+            shouldFinish = true
+        } else if hitNodeID == nil,
+                  let edgeID = route.net.edgeID(containing: loc),
+                  let newID = route.net.splitEdge(withID: edgeID, at: loc) {
+            if let splitNode = route.net.nodeByID[newID] {
+                let tol: CGFloat = 0.5
+                let startPt = route.net.nodeByID[route.startNodeID]?.point
+                let endPt = route.net.nodeByID[route.lastNodeID]?.point
+                if (startPt != nil && abs(splitNode.point.x - startPt!.x) < tol && abs(splitNode.point.y - startPt!.y) < tol)
+                    || (endPt != nil && abs(splitNode.point.x - endPt!.x) < tol && abs(splitNode.point.y - endPt!.y) < tol) {
+                    var node = splitNode
+                    node.kind = .endpoint
+                    route.net.nodeByID[newID] = node
+                }
+            }
+            targetNodeID = newID
+            shouldFinish = true
+        }
+
+        if let lastPoint = route.net.nodeByID[lastNodeID]?.point,
+           isDoubleTap(from: lastPoint, to: loc) {
+            if hitNodeID == lastNodeID {
+                return finalize()
+            }
+            builder.extend(to: loc, connectingTo: targetNodeID)
+            return finalize()
+        }
+
+        builder.extend(to: loc, connectingTo: targetNodeID)
+
+        if shouldFinish { return finalize() }
+        if context.hitSegmentID != nil { return finalize() }
+        return nil
+    }
+
+    func drawPreview(in ctx: CGContext, mouse: CGPoint, context: CanvasToolContext) {
+        guard let route = builder.snapshot,
+              let lastNode = route.net.nodeByID[route.lastNodeID] else { return }
+
+        ctx.saveGState()
+        ctx.setStrokeColor(NSColor(.blue).cgColor)
+        ctx.setLineWidth(1)
+
+        for edge in route.net.edges {
+            guard let nodeA = route.net.nodeByID[edge.startNodeID],
+                  let nodeB = route.net.nodeByID[edge.endNodeID] else { continue }
+            ctx.move(to: nodeA.point)
+            ctx.addLine(to: nodeB.point)
+        }
+        ctx.strokePath()
+
+        ctx.setLineDash(phase: 0, lengths: [4])
+        let startPoint = lastNode.point
+        if startPoint.x != mouse.x && startPoint.y != mouse.y {
+            let firstVertical = (route.lastOrientation == .horizontal)
+            let elbow = firstVertical ? CGPoint(x: startPoint.x, y: mouse.y) : CGPoint(x: mouse.x, y: startPoint.y)
+            ctx.move(to: startPoint)
+            ctx.addLine(to: elbow)
+            ctx.addLine(to: mouse)
+        } else {
+            ctx.move(to: startPoint)
+            ctx.addLine(to: mouse)
+        }
+        ctx.strokePath()
+        ctx.restoreGState()
+    }
+
+    func handleEscape() { builder.cancel() }
+    func handleBackspace() { builder.backtrack() }
+
+    private func finalize() -> CanvasElement? {
+        guard let net = builder.finishRoute() else { return nil }
+        repository.add(net)
+        let element = ConnectionElement(id: net.id, net: net)
+        return .connection(element)
+    }
+
+    private func isDoubleTap(from first: CGPoint, to second: CGPoint) -> Bool {
+        hypot(first.x - second.x, first.y - second.y) < 5
+    }
+}

--- a/CircuitPro/Routing/NetRepository.swift
+++ b/CircuitPro/Routing/NetRepository.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+final class NetRepository {
+    private(set) var nets: [Net] = []
+
+    func add(_ net: Net) {
+        nets.append(net)
+    }
+
+    func allNets() -> [Net] {
+        nets
+    }
+}

--- a/CircuitPro/Routing/RouteBuilder.swift
+++ b/CircuitPro/Routing/RouteBuilder.swift
@@ -1,0 +1,109 @@
+import CoreGraphics
+import Foundation
+
+enum RoutingOrientation {
+    case horizontal, vertical
+}
+
+protocol RoutingStrategy {
+    func route(from start: CGPoint, to end: CGPoint, lastOrientation: RoutingOrientation?) -> [CGPoint]
+}
+
+struct ManhattanRoutingStrategy: RoutingStrategy {
+    func route(from start: CGPoint, to end: CGPoint, lastOrientation: RoutingOrientation?) -> [CGPoint] {
+        if start.x != end.x && start.y != end.y {
+            let firstIsVertical = (lastOrientation == .horizontal)
+            let elbow = firstIsVertical
+                ? CGPoint(x: start.x, y: end.y)
+                : CGPoint(x: end.x, y: start.y)
+            return [elbow, end]
+        }
+        return [end]
+    }
+}
+
+final class RouteBuilder {
+    private struct RouteInProgress: Equatable, Hashable {
+        var net: Net
+        let startNodeID: UUID
+        var lastNodeID: UUID
+        var lastOrientation: RoutingOrientation?
+        let strategy: RoutingStrategy
+
+        init(startPoint: CGPoint, connectingTo existingElementID: UUID?, strategy: RoutingStrategy) {
+            let startNode = Node(id: UUID(), point: startPoint, kind: .endpoint)
+            self.net = Net(id: UUID(), nodeByID: [startNode.id: startNode], edges: [])
+            self.startNodeID = startNode.id
+            self.lastNodeID = startNode.id
+            self.strategy = strategy
+        }
+
+        mutating func extend(to point: CGPoint, connectingTo existingNodeID: UUID? = nil) {
+            guard let lastNode = net.nodeByID[lastNodeID] else { return }
+            let bendPoints = strategy.route(from: lastNode.point, to: point, lastOrientation: lastOrientation)
+            for bend in bendPoints.dropLast() {
+                let bendNode = Node(id: UUID(), point: bend, kind: .endpoint)
+                net.nodeByID[bendNode.id] = bendNode
+                net.edges.append(Edge(id: UUID(), startNodeID: lastNodeID, endNodeID: bendNode.id))
+                lastOrientation = (bend.x == lastNode.point.x) ? .vertical : .horizontal
+                lastNodeID = bendNode.id
+            }
+            let finalPoint = bendPoints.last!
+            let endID: UUID
+            if let existing = existingNodeID {
+                endID = existing
+            } else {
+                let endNode = Node(id: UUID(), point: finalPoint, kind: .endpoint)
+                net.nodeByID[endNode.id] = endNode
+                endID = endNode.id
+            }
+            net.edges.append(Edge(id: UUID(), startNodeID: lastNodeID, endNodeID: endID))
+            lastOrientation = (finalPoint.x == net.nodeByID[lastNodeID]!.point.x) ? .vertical : .horizontal
+            lastNodeID = endID
+        }
+
+        mutating func backtrack() {
+            guard let lastEdge = net.edges.popLast() else { return }
+            if net.edges.allSatisfy({ $0.startNodeID != lastEdge.endNodeID && $0.endNodeID != lastEdge.endNodeID }) {
+                net.nodeByID.removeValue(forKey: lastEdge.endNodeID)
+            }
+            lastNodeID = lastEdge.startNodeID
+            if let prevEdge = net.edges.last,
+               let start = net.nodeByID[prevEdge.startNodeID],
+               let end = net.nodeByID[prevEdge.endNodeID] {
+                lastOrientation = (start.point.x == end.point.x) ? .vertical : .horizontal
+            } else {
+                lastOrientation = nil
+            }
+        }
+    }
+
+    private var route: RouteInProgress?
+
+    var snapshot: RouteInProgress? { route }
+
+    func start(at point: CGPoint, connectingTo existingID: UUID?) {
+        route = RouteInProgress(startPoint: point, connectingTo: existingID, strategy: ManhattanRoutingStrategy())
+    }
+
+    func extend(to point: CGPoint, connectingTo existingNodeID: UUID? = nil) {
+        route?.extend(to: point, connectingTo: existingNodeID)
+    }
+
+    func backtrack() {
+        route?.backtrack()
+        if route?.net.edges.isEmpty == true { route = nil }
+    }
+
+    func finishRoute() -> Net? {
+        guard var current = route, !current.net.edges.isEmpty else {
+            route = nil
+            return nil
+        }
+        current.net.mergeColinearEdges()
+        route = nil
+        return current.net
+    }
+
+    func cancel() { route = nil }
+}


### PR DESCRIPTION
## Summary
- add new `Routing` module with `ConnectionController`, `RouteBuilder` and `NetRepository`
- slim down `ConnectionTool` to delegate interaction logic to `ConnectionController`

## Testing
- No tests run due to instructions

------
https://chatgpt.com/codex/tasks/task_e_686d71e5202c832f81cd1d8851bc9c3a