### PR TITLE
Implement pluggable merge policy

### DIFF
--- a/CircuitPro/Features/Canvas/AppKit/Controllers/CanvasInteractionController.swift
+++ b/CircuitPro/Features/Canvas/AppKit/Controllers/CanvasInteractionController.swift
@@ -3,6 +3,7 @@ import AppKit
 final class CanvasInteractionController {
 
     unowned let canvas: CoreGraphicsCanvasView
+    private let repository = NetRepository()
 
     private var dragOrigin: CGPoint?
     private var tentativeSelection: Set<UUID>?
@@ -271,7 +272,11 @@ final class CanvasInteractionController {
                     // CHANGE: The call to merge is now cleaner.
                     // The static function on ConnectionTool will contain the complex
                     // graph logic for finding and merging with existing nets.
-                    let merged = ConnectionTool.merge(conn, into: &canvas.elements)
+                    let merged = ConnectionTool.merge(
+                        conn,
+                        into: &canvas.elements,
+                        repository: repository
+                    )
                     canvas.elements.append(.connection(merged))
 
                 default:

--- a/CircuitPro/Features/_Temp/Connection/ConnectionTool.swift
+++ b/CircuitPro/Features/_Temp/Connection/ConnectionTool.swift
@@ -25,13 +25,15 @@ struct ConnectionTool: CanvasTool, Equatable, Hashable {
 
     static func merge(
         _ newElement: ConnectionElement,
-        into elements: inout [CanvasElement]
+        into elements: inout [CanvasElement],
+        repository: NetRepository
     ) -> ConnectionElement {
         var masterNet = newElement.net
         for index in (0..<elements.count).reversed() {
             guard case .connection(let existingConnection) = elements[index],
                   existingConnection.id != newElement.id else { continue }
             var existingNet = existingConnection.net
+            guard repository.mergePolicy.shouldMerge(masterNet, into: existingNet, at: .afterCommit) else { continue }
             let wasMerged = Net.findAndMergeIntentionalIntersections(
                 between: &masterNet,
                 and: &existingNet

--- a/CircuitPro/Features/_Temp/Connection/Routing/MergePolicy.swift
+++ b/CircuitPro/Features/_Temp/Connection/Routing/MergePolicy.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum MergeStage {
+    case perEdge
+    case perRoute
+    case afterCommit
+}
+
+protocol MergePolicy {
+    func shouldMerge(_ newNet: Net, into existing: Net, at stage: MergeStage) -> Bool
+}
+
+struct DefaultMergePolicy: MergePolicy {
+    func shouldMerge(_ newNet: Net, into existing: Net, at stage: MergeStage) -> Bool {
+        true
+    }
+}
+

--- a/CircuitPro/Features/_Temp/Connection/Routing/NetRepository.swift
+++ b/CircuitPro/Features/_Temp/Connection/Routing/NetRepository.swift
@@ -2,6 +2,11 @@ import Foundation
 
 final class NetRepository {
     private(set) var nets: [Net] = []
+    var mergePolicy: MergePolicy
+
+    init(mergePolicy: MergePolicy = DefaultMergePolicy()) {
+        self.mergePolicy = mergePolicy
+    }
 
     func add(_ net: Net) {
         nets.append(net)


### PR DESCRIPTION
## Summary
- define `MergeStage` and `MergePolicy`
- add default merge policy and repository property
- use repository's merge policy when merging connection nets
- expose repository to interaction controller

## Testing
- `pre-commit` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_686d765c4b5c832f8e9f94c16079f95b