### PR TITLE
Add state machine to connection routing

### DIFF
--- a/CircuitPro/Features/_Temp/Connection/ConnectionTool.swift
+++ b/CircuitPro/Features/_Temp/Connection/ConnectionTool.swift
@@ -13,15 +13,15 @@ struct ConnectionTool: CanvasTool, Equatable, Hashable {
     }
 
     mutating func handleTap(at loc: CGPoint, context: CanvasToolContext) -> CanvasElement? {
-        controller.handleTap(at: loc, context: context)
+        controller.handle(event: .tap(loc, context))
     }
 
     mutating func drawPreview(in ctx: CGContext, mouse: CGPoint, context: CanvasToolContext) {
         controller.drawPreview(in: ctx, mouse: mouse, context: context)
     }
 
-    mutating func handleEscape() { controller.handleEscape() }
-    mutating func handleBackspace() { controller.handleBackspace() }
+    mutating func handleEscape() { controller.handle(event: .escape) }
+    mutating func handleBackspace() { controller.handle(event: .backspace) }
 
     static func merge(
         _ newElement: ConnectionElement,

--- a/CircuitPro/Features/_Temp/Connection/Routing/ConnectionController.swift
+++ b/CircuitPro/Features/_Temp/Connection/Routing/ConnectionController.swift
@@ -1,20 +1,104 @@
 import CoreGraphics
 import AppKit
 
+extension ConnectionController {
+    enum Event {
+        case tap(CGPoint, CanvasToolContext)
+        case doubleTap(CGPoint, CanvasToolContext)
+        case move(CGPoint)
+        case backspace
+        case escape
+    }
+
+    enum State {
+        case idle
+        case startingRoute
+        case extendingRoute
+        case cancelling
+    }
+}
+
 final class ConnectionController {
     private let repository: NetRepository
     private let builder = RouteBuilder()
+    private(set) var state: State = .idle
 
     init(repository: NetRepository) {
         self.repository = repository
     }
 
-    func handleTap(at loc: CGPoint, context: CanvasToolContext) -> CanvasElement? {
-        if builder.snapshot == nil {
+
+    func handle(event: Event) -> CanvasElement? {
+        switch (state, event) {
+        case (.idle, .tap(let loc, let context)):
             builder.start(at: loc, connectingTo: context.hitSegmentID)
+            state = .startingRoute
+            return nil
+
+        case (.startingRoute, .tap(let loc, let context)),
+             (.extendingRoute, .tap(let loc, let context)):
+            let result = processTap(at: loc, context: context, finalize: false)
+            state = builder.snapshot == nil ? .idle : .extendingRoute
+            return result
+
+        case (.startingRoute, .doubleTap(let loc, let context)),
+             (.extendingRoute, .doubleTap(let loc, let context)):
+            let result = processTap(at: loc, context: context, finalize: true)
+            state = .idle
+            return result
+
+        case (_, .backspace):
+            builder.backtrack()
+            state = builder.snapshot == nil ? .idle : .extendingRoute
+            return nil
+
+        case (_, .escape):
+            builder.cancel()
+            state = .idle
+            return nil
+
+        case (_, .move):
             return nil
         }
+    }
 
+    func drawPreview(in ctx: CGContext, mouse: CGPoint, context: CanvasToolContext) {
+        guard state != .idle,
+              let route = builder.snapshot,
+              let lastNode = route.net.nodeByID[route.lastNodeID] else { return }
+
+        ctx.saveGState()
+        ctx.setStrokeColor(NSColor(.blue).cgColor)
+        ctx.setLineWidth(1)
+
+        for edge in route.net.edges {
+            guard let nodeA = route.net.nodeByID[edge.startNodeID],
+                  let nodeB = route.net.nodeByID[edge.endNodeID] else { continue }
+            ctx.move(to: nodeA.point)
+            ctx.addLine(to: nodeB.point)
+        }
+        ctx.strokePath()
+
+        ctx.setLineDash(phase: 0, lengths: [4])
+        let startPoint = lastNode.point
+        if startPoint.x != mouse.x && startPoint.y != mouse.y {
+            let firstVertical = (route.lastOrientation == .horizontal)
+            let elbow = firstVertical ? CGPoint(x: startPoint.x, y: mouse.y) : CGPoint(x: mouse.x, y: startPoint.y)
+            ctx.move(to: startPoint)
+            ctx.addLine(to: elbow)
+            ctx.addLine(to: mouse)
+        } else {
+            ctx.move(to: startPoint)
+            ctx.addLine(to: mouse)
+        }
+        ctx.strokePath()
+        ctx.restoreGState()
+    }
+
+    func handleEscape() { _ = handle(event: .escape) }
+    func handleBackspace() { _ = handle(event: .backspace) }
+
+    private func processTap(at loc: CGPoint, context: CanvasToolContext, finalize: Bool) -> CanvasElement? {
         guard var route = builder.snapshot else { return nil }
         var targetNodeID: UUID? = nil
         var shouldFinish = false
@@ -47,13 +131,12 @@ final class ConnectionController {
             shouldFinish = true
         }
 
-        if let lastPoint = route.net.nodeByID[lastNodeID]?.point,
-           isDoubleTap(from: lastPoint, to: loc) {
+        if finalize {
             if hitNodeID == lastNodeID {
-                return finalize()
+                return self.finalize()
             }
             builder.extend(to: loc, connectingTo: targetNodeID)
-            return finalize()
+            return self.finalize()
         }
 
         builder.extend(to: loc, connectingTo: targetNodeID)
@@ -63,41 +146,6 @@ final class ConnectionController {
         return nil
     }
 
-    func drawPreview(in ctx: CGContext, mouse: CGPoint, context: CanvasToolContext) {
-        guard let route = builder.snapshot,
-              let lastNode = route.net.nodeByID[route.lastNodeID] else { return }
-
-        ctx.saveGState()
-        ctx.setStrokeColor(NSColor(.blue).cgColor)
-        ctx.setLineWidth(1)
-
-        for edge in route.net.edges {
-            guard let nodeA = route.net.nodeByID[edge.startNodeID],
-                  let nodeB = route.net.nodeByID[edge.endNodeID] else { continue }
-            ctx.move(to: nodeA.point)
-            ctx.addLine(to: nodeB.point)
-        }
-        ctx.strokePath()
-
-        ctx.setLineDash(phase: 0, lengths: [4])
-        let startPoint = lastNode.point
-        if startPoint.x != mouse.x && startPoint.y != mouse.y {
-            let firstVertical = (route.lastOrientation == .horizontal)
-            let elbow = firstVertical ? CGPoint(x: startPoint.x, y: mouse.y) : CGPoint(x: mouse.x, y: startPoint.y)
-            ctx.move(to: startPoint)
-            ctx.addLine(to: elbow)
-            ctx.addLine(to: mouse)
-        } else {
-            ctx.move(to: startPoint)
-            ctx.addLine(to: mouse)
-        }
-        ctx.strokePath()
-        ctx.restoreGState()
-    }
-
-    func handleEscape() { builder.cancel() }
-    func handleBackspace() { builder.backtrack() }
-
     private func finalize() -> CanvasElement? {
         guard let net = builder.finishRoute() else { return nil }
         repository.add(net)
@@ -105,7 +153,4 @@ final class ConnectionController {
         return .connection(element)
     }
 
-    private func isDoubleTap(from first: CGPoint, to second: CGPoint) -> Bool {
-        hypot(first.x - second.x, first.y - second.y) < 5
-    }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "CircuitPro",
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(name: "CircuitPro", targets: ["CircuitPro"]),
+    ],
+    targets: [
+        .target(name: "CircuitPro", path: "CircuitPro"),
+        .testTarget(name: "CircuitProTests", dependencies: ["CircuitPro"], path: "Tests")
+    ]
+)

--- a/Tests/InteractionStateTests/InteractionStateTests.swift
+++ b/Tests/InteractionStateTests/InteractionStateTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import CircuitPro
+
+final class InteractionStateTests: XCTestCase {
+    func testIdleToStarting() {
+        let controller = ConnectionController(repository: NetRepository())
+        XCTAssertNil(controller.handle(event: .tap(.zero, CanvasToolContext())))
+        XCTAssertEqual(controller.state, .startingRoute)
+    }
+
+    func testBackspaceResetsToIdle() {
+        let controller = ConnectionController(repository: NetRepository())
+        _ = controller.handle(event: .tap(.zero, CanvasToolContext()))
+        controller.handle(event: .backspace)
+        XCTAssertEqual(controller.state, .idle)
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple state machine in `ConnectionController`
- route events from `ConnectionTool` to state machine
- add Swift Package manifest for running tests
- create `InteractionStateTests`

## Testing
- `swift test --enable-test-discovery` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686d7bbbe558832f8efe4427462ca04c