### PR TITLE
Remove grid spacing menu from schematic

### DIFF
--- a/CircuitPro/Features/Editor/EditorView.swift
+++ b/CircuitPro/Features/Editor/EditorView.swift
@@ -44,7 +44,11 @@ struct EditorView: View {
                 }
 
             } dividerView: {
-                StatusBarView(canvasManager: selectedCanvasManager, showUtilityArea: $showUtilityArea)
+                StatusBarView(
+                    canvasManager: selectedCanvasManager,
+                    editorType: selectedEditor,
+                    showUtilityArea: $showUtilityArea
+                )
             } bottomView: {
                 UtilityAreaView()
             }

--- a/CircuitPro/Features/Workspace/UtilityArea/StatusBarView.swift
+++ b/CircuitPro/Features/Workspace/UtilityArea/StatusBarView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct StatusBarView: View {
 
     var canvasManager: CanvasManager
+    var editorType: EditorType
 
     @Binding var showUtilityArea: Bool
 
@@ -29,10 +30,12 @@ struct StatusBarView: View {
             .foregroundStyle(.secondary)
 
             Spacer()
-            GridSpacingControlView()
-            Divider()
-                .foregroundStyle(.quinary)
-                .frame(height: 12)
+            if editorType != .schematic {
+                GridSpacingControlView()
+                Divider()
+                    .foregroundStyle(.quinary)
+                    .frame(height: 12)
+            }
             ZoomControlView()
             Divider()
                 .foregroundStyle(.quinary)
@@ -55,5 +58,5 @@ struct StatusBarView: View {
 }
 
 #Preview {
-    StatusBarView(canvasManager: .init(), showUtilityArea: .constant(true))
+    StatusBarView(canvasManager: .init(), editorType: .schematic, showUtilityArea: .constant(true))
 }


### PR DESCRIPTION
## Summary
- hide grid spacing option when in Schematic editor
- pass the editor type to StatusBarView

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6870c712bb20832fbbd59981601a7888