### PR TITLE
Link canvas & navigator selections

### DIFF
--- a/CircuitPro/Features/Editor/SchematicView.swift
+++ b/CircuitPro/Features/Editor/SchematicView.swift
@@ -12,16 +12,17 @@ struct SchematicView: View {
 
     // canvas state
     @State private var canvasElements: [CanvasElement] = []
-    @State private var selectedIDs: Set<UUID> = []
     @State private var selectedTool: AnyCanvasTool = .init(CursorTool())
 
     @State private var debugString: String?
 
     var body: some View {
+        @Bindable var bindableProjectManager = projectManager
+
         CanvasView(
             manager: canvasManager,
             elements: $canvasElements,
-            selectedIDs: $selectedIDs,
+            selectedIDs: $bindableProjectManager.selectedComponentIDs,
             selectedTool: $selectedTool
         )
         .dropDestination(for: TransferableComponent.self) { dropped, loc in

--- a/CircuitPro/Managers/ProjectManager.swift
+++ b/CircuitPro/Managers/ProjectManager.swift
@@ -14,6 +14,7 @@ final class ProjectManager {
     private let modelContext: ModelContext
     var project: CircuitProject
     var selectedDesign: CircuitDesign?
+    var selectedComponentIDs: Set<UUID> = []
 
     init(
         project: CircuitProject,


### PR DESCRIPTION
## Summary
- add `selectedComponentIDs` to `ProjectManager` for global selection state
- bind `SchematicView` canvas selections to `selectedComponentIDs`
- bind `SymbolNavigatorView` list selection to the same property

## Testing
- `swift test --enable-code-coverage` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68703635e488832fb049a83a02291d0d