### PR TITLE
Fix connection update persistence

### DIFF
--- a/CircuitPro/Features/Canvas/AppKit/Controllers/CanvasInteractionController.swift
+++ b/CircuitPro/Features/Canvas/AppKit/Controllers/CanvasInteractionController.swift
@@ -412,9 +412,11 @@ final class CanvasInteractionController {
             // Merge into the first matching existing connection.
             let primaryIdx = indicesToMerge.first!
 
-            if case .connection(let primaryConn) = canvas.elements[primaryIdx] {
+            if case .connection(var primaryConn) = canvas.elements[primaryIdx] {
                 primaryConn.graph.merge(with: newConn.graph)
                 primaryConn.graph.simplifyCollinearSegments() // Simplify after merge
+                primaryConn.markChanged()
+                canvas.elements[primaryIdx] = .connection(primaryConn)
             }
 
             // Merge additional overlapping connection elements into the primary one.
@@ -423,15 +425,19 @@ final class CanvasInteractionController {
             // We'll iterate from the back to keep indices valid when removing.
             for idx in indicesToMerge.dropFirst().sorted(by: >) {
                 if case .connection(let extraConn) = canvas.elements[idx] {
-                    if case .connection(let primaryConn) = canvas.elements[primaryIdx] {
+                    if case .connection(var primaryConn) = canvas.elements[primaryIdx] {
                         primaryConn.graph.merge(with: extraConn.graph)
+                        primaryConn.markChanged()
+                        canvas.elements[primaryIdx] = .connection(primaryConn)
                     }
                 }
                 canvas.elements.remove(at: idx)
             }
             // Ensure the primary connection is simplified after all merges
-            if case .connection(let primaryConn) = canvas.elements[primaryIdx] {
+            if case .connection(var primaryConn) = canvas.elements[primaryIdx] {
                 primaryConn.graph.simplifyCollinearSegments()
+                primaryConn.markChanged()
+                canvas.elements[primaryIdx] = .connection(primaryConn)
             }
         }
     }

--- a/CircuitPro/Features/Canvas/Model/CanvasElement.swift
+++ b/CircuitPro/Features/Canvas/Model/CanvasElement.swift
@@ -154,9 +154,11 @@ extension CanvasElement {
             pad.position = orig + delta; self = .pad(pad)
         case .symbol(var symbol):
             symbol.position = orig + delta; self = .symbol(symbol)
-        case .connection(let connection):
-            // For a connection, we translate all vertices in its graph.
+        case .connection(var connection):
+            // For a connection, translate all vertices and mark dirty.
             connection.graph.translate(by: delta)
+            connection.markChanged()
+            self = .connection(connection)
         }
     }
 }

--- a/CircuitPro/Features/_Temp/Connection/ConnectionElement.swift
+++ b/CircuitPro/Features/_Temp/Connection/ConnectionElement.swift
@@ -11,12 +11,16 @@ struct ConnectionElement: Identifiable, Drawable, Hittable {
 
     // MARK: – Identity
     let id: UUID
+    private(set) var revision: Int = 0
 
     // MARK: - Data Model
     /// The underlying graph representing the connection net.
     /// Using a class for ConnectionGraph allows for reference semantics,
     /// where multiple elements could potentially share and manipulate the same net.
     let graph: ConnectionGraph
+
+    // Bump this whenever the underlying graph changes so SwiftUI detects updates
+    mutating func markChanged() { revision &+= 1 }
 
     // MARK: – Init
     init(
@@ -25,6 +29,7 @@ struct ConnectionElement: Identifiable, Drawable, Hittable {
     ) {
         self.id = id
         self.graph = graph
+        self.revision = 0
     }
 
     // MARK: – Derived geometry
@@ -218,6 +223,11 @@ struct ConnectionElement: Identifiable, Drawable, Hittable {
 
 // MARK: – Hashable & Equatable
 extension ConnectionElement: Hashable, Equatable {
-    static func == (lhs: ConnectionElement, rhs: ConnectionElement) -> Bool { lhs.id == rhs.id }
-    func hash(into hasher: inout Hasher) { hasher.combine(id) }
+    static func == (lhs: ConnectionElement, rhs: ConnectionElement) -> Bool {
+        lhs.id == rhs.id && lhs.revision == rhs.revision
+    }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(revision)
+    }
 }


### PR DESCRIPTION
## Summary
- track updates on ConnectionElement via new `revision` and bump when mutated
- mark connections dirty when translating or merging to ensure SwiftUI detects changes

## Testing
- `swift test` *(fails: invalid custom path)*
- `swift build` *(fails: invalid custom path)*

------
https://chatgpt.com/codex/tasks/task_e_6871365ab7cc832fa4429dab7b6573d8