### PR TITLE
Switch to cursor after cancel

### DIFF
--- a/CircuitPro/Features/Canvas/AppKit/Controllers/Helpers/WorkbenchKeyCommandController.swift
+++ b/CircuitPro/Features/Canvas/AppKit/Controllers/Helpers/WorkbenchKeyCommandController.swift
@@ -49,8 +49,12 @@ final class WorkbenchKeyCommandController {
         // Escape
         case "\u{1b}":
             if var tool = workbench.selectedTool, tool.id != "cursor" {
-                tool.handleEscape()
-                workbench.selectedTool = tool
+                let canceled = tool.handleEscape()
+                if canceled {
+                    workbench.selectedTool = tool
+                } else {
+                    workbench.selectedTool = AnyCanvasTool(CursorTool())
+                }
                 return true
             }
 

--- a/CircuitPro/Features/Toolbar/Tool/AnyCanvasTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/AnyCanvasTool.swift
@@ -15,7 +15,7 @@ struct AnyCanvasTool: CanvasTool {
 
     private let _handleTap: (CGPoint, CanvasToolContext) -> CanvasToolResult
     private let _preview: (CGPoint, CanvasToolContext) -> [DrawingParameters]
-    private let _handleEscape: () -> Void
+    private let _handleEscape: () -> Bool
     private let _handleBackspace: () -> Void
     private let _handleRotate: () -> Void
     private let _handleReturn: () -> CanvasToolResult
@@ -48,8 +48,9 @@ struct AnyCanvasTool: CanvasTool {
         // ----- handleEscape -------------------------------------------------
         _handleEscape = {
             var inner = storage.tool
-            inner.handleEscape()
+            let result = inner.handleEscape()
             storage.tool = inner
+            return result
         }
 
         // ----- handleBackspace ----------------------------------------------
@@ -84,8 +85,8 @@ struct AnyCanvasTool: CanvasTool {
         _preview(mouse, context)
     }
 
-    mutating func handleEscape() {
-        _handleEscape()
+    mutating func handleEscape() -> Bool {
+        return _handleEscape()
     }
 
     mutating func handleBackspace() {

--- a/CircuitPro/Features/Toolbar/Tool/CanvasTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/CanvasTool.swift
@@ -21,7 +21,7 @@ protocol CanvasTool: Hashable {
     // NEW: keyboard actions -------------------------------------------------
     /// Called when the user presses the Escape key while this tool is active.
     /// Tools can reset any in-progress state here.
-    mutating func handleEscape()
+    mutating func handleEscape() -> Bool
 
     /// Called when the Backspace key is pressed. Tools should undo the most
     /// recent step of the operation if possible.
@@ -44,7 +44,7 @@ extension CanvasTool {
 
     mutating func preview(mouse: CGPoint, context: CanvasToolContext) -> [DrawingParameters] { [] }
 
-    mutating func handleEscape() {}
+    mutating func handleEscape() -> Bool { false }
 
     mutating func handleBackspace() {}
 

--- a/CircuitPro/Features/Toolbar/Tool/Graphics/CircleTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Graphics/CircleTool.swift
@@ -42,8 +42,9 @@ struct CircleTool: CanvasTool {
         )]
     }
 
-    mutating func handleEscape() {
-        center = nil
+    mutating func handleEscape() -> Bool {
+        defer { center = nil }
+        return center != nil
     }
 
     mutating func handleBackspace() {

--- a/CircuitPro/Features/Toolbar/Tool/Graphics/LineTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Graphics/LineTool.swift
@@ -48,8 +48,9 @@ struct LineTool: CanvasTool {
         )]
     }
 
-    mutating func handleEscape() {
-        start = nil
+    mutating func handleEscape() -> Bool {
+        defer { start = nil }
+        return start != nil
     }
 
     mutating func handleBackspace() {

--- a/CircuitPro/Features/Toolbar/Tool/Graphics/RectangleTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Graphics/RectangleTool.swift
@@ -45,8 +45,9 @@ struct RectangleTool: CanvasTool {
         )]
     }
 
-    mutating func handleEscape() {
-        start = nil
+    mutating func handleEscape() -> Bool {
+        defer { start = nil }
+        return start != nil
     }
 
     mutating func handleBackspace() {

--- a/CircuitPro/Features/Toolbar/Tool/Utility/RulerTool.swift
+++ b/CircuitPro/Features/Toolbar/Tool/Utility/RulerTool.swift
@@ -111,10 +111,12 @@ struct RulerTool: CanvasTool {
         return allParameters
     }
 
-    mutating func handleEscape() {
+    mutating func handleEscape() -> Bool {
+        let hadState = start != nil || end != nil || clicks != 0
         start = nil
         end = nil
         clicks = 0
+        return hadState
     }
 
     mutating func handleBackspace() {

--- a/CircuitPro/Features/_Temp/Connection/ConnectionTool.swift
+++ b/CircuitPro/Features/_Temp/Connection/ConnectionTool.swift
@@ -112,8 +112,12 @@ struct ConnectionTool: CanvasTool, Equatable, Hashable {
     }
 
     // MARK: - Tool State Management
-    mutating func handleEscape() {
-        if case .drawing = state { state = .idle }
+    mutating func handleEscape() -> Bool {
+        if case .drawing = state {
+            state = .idle
+            return true
+        }
+        return false
     }
 
     mutating func handleReturn() -> CanvasToolResult {


### PR DESCRIPTION
## Summary
- update escape handling so it returns a Bool
- switch to the cursor tool when escape is pressed twice
- update tools to report if escape cancelled current workflow

## Testing
- `swift build` *(fails: 'circuitpro': invalid custom path 'Tests' for target 'CircuitProTests')*

------
https://chatgpt.com/codex/tasks/task_e_6888d75afc78832f8c0a63eb53f12ec8