### PR TITLE
Close ECO sync sheet after applying selection

### DIFF
--- a/CircuitPro/Features/_Temp/TimelineView.swift
+++ b/CircuitPro/Features/_Temp/TimelineView.swift
@@ -216,6 +216,7 @@ struct TimelineView: View {
                 Button("Apply \(selection.count) Selected") {
                     projectManager.applyChanges(withIDs: selection, allFootprints: allFootprints)
                     selection.removeAll()
+                    dismiss()
                 }
                 .buttonStyle(.borderedProminent)
             }


### PR DESCRIPTION
## Summary
- dismiss the ECO sync timeline sheet after applying the selected set of changes so the modal closes consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d90c74ff40832f9694ab09943bb14d