### PR TITLE
Relax inspector sizing to avoid constraint loops

### DIFF
--- a/CircuitPro/Features/Workspace/WorkspaceView.swift
+++ b/CircuitPro/Features/Workspace/WorkspaceView.swift
@@ -73,10 +73,10 @@ struct WorkspaceView: View {
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             NavigatorView()
-                .navigationSplitViewColumnWidth(min: 240, ideal: 240, max: 320)
+                .navigationSplitViewColumnWidth(min: 210, ideal: 240, max: 320)
         } detail: {
             EditorView()
-                .frame(minWidth: 320)
+                .frame(minWidth: 300)
                 .sheet(isPresented: $showFeedbackSheet) {
                     FeedbackFormView()
                         .frame(minWidth: 400, minHeight: 300)
@@ -115,10 +115,10 @@ struct WorkspaceView: View {
                     }
                 }
         }
-        .frame(minWidth: 820, minHeight: 600)
+        .frame(minWidth: 780, minHeight: 600)
         .inspector(isPresented: $showInspector) {
             InspectorView()
-            .inspectorColumnWidth(min: 260, ideal: 300, max: 500)
+            .inspectorColumnWidth(min: 220, ideal: 300, max: 500)
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button {

--- a/CircuitPro/Features/_Temp/Inspector/InspectorView.swift
+++ b/CircuitPro/Features/_Temp/Inspector/InspectorView.swift
@@ -108,13 +108,13 @@ struct InspectorView: View {
     /// A shared view for displaying the current selection status (none, or multiple).
     @ViewBuilder
     private var selectionStatusView: some View {
-        VStack {
-            Spacer()
+        ZStack {
             Text(projectManager.selectedNodeIDs.isEmpty ? "No Selection" : "Multiple Items Selected")
                 .foregroundColor(.secondary)
-            Spacer()
+                .multilineTextAlignment(.center)
+                .padding()
         }
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 


### PR DESCRIPTION
## Summary
- lower the navigation split view and inspector column minimum widths to give AppKit more flexibility when the inspector is shown
- allow the editor column to compress slightly and reduce the workspace minimum window width accordingly
- update the empty-state inspector view to fill its container without using opposing spacers

## Testing
- `swift build` *(fails: 'circuitpro': invalid custom path 'Tests' for target 'CircuitProTests')*

------
https://chatgpt.com/codex/tasks/task_e_68d90b880f9c832f9321729ce3dcc53f